### PR TITLE
Make src an installable package

### DIFF
--- a/llmfy
+++ b/llmfy
@@ -8,9 +8,6 @@ Transform raw documents into high-quality, LLM-ready knowledge chunks.
 import sys
 from pathlib import Path
 
-# Add src to path
-sys.path.insert(0, str(Path(__file__).parent))
-
 # Import the main llmfy command
 from llmfy import main
 

--- a/llmfy_ingest.py
+++ b/llmfy_ingest.py
@@ -16,9 +16,6 @@ from rich.panel import Panel
 from rich.progress import track
 from rich.prompt import Confirm
 
-# Add src to path
-sys.path.insert(0, str(Path(__file__).parent))
-
 from src.core.smart_ingestion import SmartIngestionPlanner
 
 console = Console()

--- a/llmfy_quickstart.py
+++ b/llmfy_quickstart.py
@@ -244,7 +244,6 @@ MAX_MONTHLY_COST=100
         # Test imports
         test_script = """
 import sys
-sys.path.insert(0, '.')
 
 try:
     from src.core.config import Config

--- a/llmfy_validator.py
+++ b/llmfy_validator.py
@@ -18,9 +18,6 @@ from rich.table import Table
 from rich.panel import Panel
 from rich.progress import track
 
-# Add src to path
-sys.path.insert(0, str(Path(__file__).parent))
-
 from src.quality.quality_scorer import QualityAnalyzer
 
 console = Console()

--- a/process_ui_guide.py
+++ b/process_ui_guide.py
@@ -7,9 +7,6 @@ import sys
 import os
 from pathlib import Path
 
-# Add src to path
-sys.path.insert(0, str(Path(__file__).parent / 'src'))
-
 # Import our modules
 from src.quality.quality_scorer import KnowledgeQualityAnalyzer as QualityAnalyzer
 from src.quality.quality_enhancer import QualityEnhancer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "llmfy"
+version = "0.1.0"
+description = "Quality-first document processing toolkit"
+readme = "README.md"
+requires-python = ">=3.8"
+
+[project.scripts]
+llmfy = "llmfy:main"
+
+[tool.setuptools.packages.find]
+include = ["src*"]

--- a/run_blind_test.py
+++ b/run_blind_test.py
@@ -6,9 +6,6 @@ Quick script to run blind test on already processed documents
 import sys
 from pathlib import Path
 
-# Add src to path
-sys.path.insert(0, str(Path(__file__).parent))
-
 from src.evaluation.blind_test import BlindTestEvaluator
 
 def main():

--- a/src/core/llmfy_pipeline.py
+++ b/src/core/llmfy_pipeline.py
@@ -5,22 +5,18 @@
 This is the main pipeline that transforms documents into LLM-ready chunks.
 """
 
-import sys
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timezone
 import json
 
-# Add parent directory to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-
-from src.core.pipeline import KnowledgeBasePipeline
-from src.core.document_loader import DocumentLoader
-from src.core.text_processor_v2 import TextProcessorV2SlidingWindow, ChunkingConfig
-from src.quality.quality_scorer_v2 import ImprovedQualityAnalyzer as QualityAnalyzer
-from src.quality.quality_enhancer import QualityEnhancer
-from src.embeddings.hybrid_embedder import HybridEmbedder
-from src.core.chunk_optimizer import ChunkOptimizer
+from .pipeline import KnowledgeBasePipeline
+from .document_loader import DocumentLoader
+from .text_processor_v2 import TextProcessorV2SlidingWindow, ChunkingConfig
+from ..quality.quality_scorer_v2 import ImprovedQualityAnalyzer as QualityAnalyzer
+from ..quality.quality_enhancer import QualityEnhancer
+from ..embeddings.hybrid_embedder import HybridEmbedder
+from .chunk_optimizer import ChunkOptimizer
 
 from rich.console import Console
 from rich.panel import Panel
@@ -337,7 +333,7 @@ class LlmfyPipeline(KnowledgeBasePipeline):
         
         if Confirm.ask("\n[cyan]Would you like to run a blind test evaluation?[/cyan]"):
             try:
-                from src.evaluation.blind_test import BlindTestEvaluator
+                from ..evaluation.blind_test import BlindTestEvaluator
                 console.print("\n[bold]🔍 Starting blind test evaluation...[/bold]")
                 
                 evaluator = BlindTestEvaluator()

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import sys
 from pathlib import Path
 from typing import Optional, List, Dict, Any
 import argparse
@@ -10,9 +9,6 @@ import json
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
-
-# Add src to path
-sys.path.insert(0, str(Path(__file__).parent))
 
 from .config import Config
 from .document_loader import DocumentLoader

--- a/src/embeddings/hybrid_embedder.py
+++ b/src/embeddings/hybrid_embedder.py
@@ -4,17 +4,13 @@
 """
 
 import os
-import sys
 from pathlib import Path
 from typing import List, Dict, Any, Union, Tuple
 import hashlib
 import json
 from datetime import datetime
 
-# Add parent directory to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-
-from src.core.embedding_generator import EmbeddingGenerator
+from ..core.embedding_generator import EmbeddingGenerator
 
 try:
     from sentence_transformers import SentenceTransformer

--- a/src/embeddings/hybrid_embedder_old.py
+++ b/src/embeddings/hybrid_embedder_old.py
@@ -7,17 +7,13 @@ selectively using OpenAI for production.
 """
 
 import os
-import sys
 from pathlib import Path
 from typing import List, Dict, Any, Union
 import hashlib
 import json
 from datetime import datetime
 
-# Add parent directory to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-
-from src.core.embedding_generator import EmbeddingGenerator
+from ..core.embedding_generator import EmbeddingGenerator
 
 try:
     from sentence_transformers import SentenceTransformer

--- a/test_new_scorer.py
+++ b/test_new_scorer.py
@@ -5,7 +5,6 @@ Test the new quality scorer with real examples
 
 import sys
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent))
 
 from src.quality.quality_scorer import KnowledgeQualityAnalyzer as OldAnalyzer
 from src.quality.quality_scorer_v2 import ImprovedQualityAnalyzer as NewAnalyzer


### PR DESCRIPTION
## Summary
- convert `src` directory into an installable package via `pyproject.toml`
- switch internal imports to relative form
- drop all `sys.path.insert` calls in scripts and modules

## Testing
- `pytest -q`
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_b_6881aa5185208325a6b92bf71e6b562a