### PR TITLE
Add unit tests for smart chunking and quality analyzer

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))

--- a/tests/test_quality_analyzer_v2.py
+++ b/tests/test_quality_analyzer_v2.py
@@ -1,0 +1,26 @@
+import pytest
+
+from src.quality.quality_scorer_v2 import ImprovedQualityAnalyzer
+
+@pytest.fixture
+def analyzer():
+    return ImprovedQualityAnalyzer()
+
+@pytest.fixture
+def sample_text():
+    return (
+        "Instead, top designers use off-black and tinted dark palettes. "
+        "For example, Google's Material Design dark theme recommends a very dark gray (#121212) as the base surface color. "
+        "This softer black reduces eye strain in low-light conditions and prevents the high contrast issues of pure black."
+    )
+
+
+def test_analyze_returns_expected_score(analyzer, sample_text):
+    result = analyzer.analyze(sample_text)
+    assert pytest.approx(result["overall_score"], 0.01) == 7.87
+    assert set(result["strengths"]) == {"context_independence", "semantic_coherence", "clarity"}
+
+
+def test_analyze_artifact_returns_zero(analyzer):
+    result = analyzer.analyze("12345")
+    assert result["overall_score"] == 0.0

--- a/tests/test_text_processor_v2.py
+++ b/tests/test_text_processor_v2.py
@@ -1,0 +1,24 @@
+import pytest
+from langchain.schema import Document
+
+from src.core.text_processor_v2 import TextProcessorV2, ChunkingConfig
+
+@pytest.fixture
+def sample_document():
+    text = (
+        "## Intro\nThis is introduction.\n\n"
+        "## Details\nMore details about things.\n\n"
+        "## Conclusion\nThe end."
+    )
+    return Document(page_content=text, metadata={"filename": "sample.md"})
+
+
+def test_smart_chunk_document_returns_expected_chunks(sample_document):
+    config = ChunkingConfig(min_chunk_size=1, chunk_size=100, chunk_overlap=0)
+    processor = TextProcessorV2(config=config, use_semantic_chunking=False)
+    chunks = processor.smart_chunk_document(sample_document)
+
+    assert len(chunks) == 3
+    assert [c.metadata["chunk_index"] for c in chunks] == [0, 1, 2]
+    assert all(c.metadata["chunk_total"] == 3 for c in chunks)
+    assert all(c.page_content.startswith("[Context: Document: Sample") for c in chunks)


### PR DESCRIPTION
## Summary
- add pytest configuration to limit collected test paths
- add fixtures and tests for `TextProcessorV2.smart_chunk_document`
- add fixtures and tests for `ImprovedQualityAnalyzer.analyze`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6881aa52f10c83259a62bf3589680f53