### PR TITLE
Replace Nexus references with llmfy

### DIFF
--- a/SETUP_COMPLETE.md
+++ b/SETUP_COMPLETE.md
@@ -1,8 +1,8 @@
-# ✅ Nexus AI Library Setup Complete!
+# ✅ llmfy AI Library Setup Complete!
 
 ## What We've Built
 
-The **Nexus AI Library System** is now fully configured and ready to use. This is a production-ready, quality-first knowledge management system that ensures every piece of content meets a 9.5/10 quality standard.
+The **llmfy AI Library System** is now fully configured and ready to use. This is a production-ready, quality-first knowledge management system that ensures every piece of content meets a 9.5/10 quality standard.
 
 ## 🔑 Your Configuration
 
@@ -21,7 +21,7 @@ The **Nexus AI Library System** is now fully configured and ready to use. This i
 
 ### 1. Activate Virtual Environment
 ```bash
-cd /Users/lech/02_knowledge/nexus_ai_library
+cd /Users/lech/02_knowledge/llmfy_ai_library
 source venv/bin/activate
 ```
 
@@ -33,12 +33,12 @@ pip install langchain chromadb sentence-transformers openai pinecone-client
 ### 3. Process Your First Document
 ```bash
 # The test document is already in data/inbox/
-python -m src.core.nexus_pipeline --input data/inbox/test_document.md
+python -m src.core.llmfy_pipeline --input data/inbox/test_document.md
 ```
 
 ### 4. Validate Quality
 ```bash
-python nexus_validator.py data/processed/
+python llmfy_validator.py data/processed/
 ```
 
 ## 📊 Expected Results
@@ -69,7 +69,7 @@ When you process the test document:
 - **Auto Enhancement**: Enabled
 
 ### To Switch to Production
-Edit `config/nexus_config.yaml`:
+Edit `config/llmfy_config.yaml`:
 ```yaml
 environment: production  # Changed from development
 ```
@@ -82,17 +82,17 @@ This will:
 ## 📁 Project Structure
 
 ```
-nexus_ai_library/
+llmfy_ai_library/
 ├── 🚀 Core Scripts
-│   ├── nexus_quickstart.py    # One-command setup
-│   └── nexus_validator.py     # Quality validation
+│   ├── llmfy_quickstart.py    # One-command setup
+│   └── llmfy_validator.py     # Quality validation
 ├── 📦 Source Code (src/)
 │   ├── core/                  # Pipeline, config, orchestration
 │   ├── quality/               # Scoring & enhancement
 │   ├── embeddings/            # Hybrid embedder
 │   └── (storage, retrieval, mcp...)
 ├── ⚙️  Configuration
-│   └── config/nexus_config.yaml
+│   └── config/llmfy_config.yaml
 ├── 📂 Data
 │   ├── inbox/                 # New documents go here
 │   ├── processed/             # Quality-approved content
@@ -123,7 +123,7 @@ Every chunk is scored on:
 
 1. **Test the System**:
    ```bash
-   python -m src.core.nexus_pipeline --input data/inbox/test_document.md
+   python -m src.core.llmfy_pipeline --input data/inbox/test_document.md
    ```
 
 2. **Process Your Existing Content**:
@@ -132,12 +132,12 @@ Every chunk is scored on:
    cp /Users/lech/02_knowledge/librarian/raw_documents/*.md data/inbox/
    
    # Process all
-   python -m src.core.nexus_pipeline
+   python -m src.core.llmfy_pipeline
    ```
 
 3. **Monitor Quality**:
    ```bash
-   python nexus_validator.py data/processed/
+   python llmfy_validator.py data/processed/
    ```
 
 4. **Check Costs**:
@@ -153,6 +153,6 @@ Every chunk is scored on:
 
 ## 🎉 Congratulations!
 
-Your Nexus AI Library is ready to ensure that every piece of knowledge in your system meets the highest quality standards. This will enable LLMs to provide exceptional, accurate, and comprehensive responses.
+Your llmfy AI Library is ready to ensure that every piece of knowledge in your system meets the highest quality standards. This will enable LLMs to provide exceptional, accurate, and comprehensive responses.
 
 Remember: **Quality isn't just a feature—it's the foundation.**

--- a/SMART_INGESTION_GUIDE.md
+++ b/SMART_INGESTION_GUIDE.md
@@ -1,13 +1,13 @@
-# 🤖 Nexus Smart Ingestion System
+# 🤖 llmfy Smart Ingestion System
 
 ## Overview
 
-The Nexus AI Library now features **Smart Ingestion** - an intelligent system that analyzes documents BEFORE processing to create optimal ingestion plans.
+The llmfy AI Library now features **Smart Ingestion** - an intelligent system that analyzes documents BEFORE processing to create optimal ingestion plans.
 
 ## How It Works
 
 ### 1. Document Analysis
-When you ingest a document, Nexus:
+When you ingest a document, llmfy:
 - **Profiles the document type**: Technical, Tutorial, Reference, or Narrative
 - **Analyzes structure**: Linear, Hierarchical, or Fragmented
 - **Detects special features**: Code blocks, tables, images, etc.
@@ -15,7 +15,7 @@ When you ingest a document, Nexus:
 - **Extracts topics**: Identifies main subjects and themes
 
 ### 2. Intelligent Planning
-Based on analysis, Nexus creates a plan:
+Based on analysis, llmfy creates a plan:
 - **Optimal chunk size**: Varies by document type (1000-2000 chars)
 - **Smart chunking strategy**: Code-aware, step-aware, or header-aware
 - **Enhancement strategies**: What improvements are needed
@@ -35,22 +35,22 @@ Works with ANY document type:
 ### Smart Ingestion (Recommended)
 ```bash
 # Analyze and ingest with smart planning
-python nexus_ingest.py /path/to/document.md
+python llmfy_ingest.py /path/to/document.md
 
 # Smart ingestion with auto-processing
-python nexus_ingest.py /path/to/document.md --process
+python llmfy_ingest.py /path/to/document.md --process
 ```
 
 ### Simple Ingestion
 ```bash
 # Skip analysis (not recommended)
-python nexus_ingest.py /path/to/document.md --no-smart
+python llmfy_ingest.py /path/to/document.md --no-smart
 ```
 
-### Using the Main Nexus Command
+### Using the Main llmfy Command
 ```bash
 # One command for everything
-python nexus.py ingest /path/to/document.md --process
+python llmfy.py ingest /path/to/document.md --process
 ```
 
 ## Example Output
@@ -136,7 +136,7 @@ If document quality is below 9.5/10, smart ingestion plans:
 
 ```bash
 # Smart ingestion on the UI/UX guide
-python nexus_ingest.py data/inbox/architects_guide_ui_ux.md
+python llmfy_ingest.py data/inbox/architects_guide_ui_ux.md
 
 # Watch as it:
 # 1. Analyzes the document type (Technical)
@@ -148,5 +148,5 @@ python nexus_ingest.py data/inbox/architects_guide_ui_ux.md
 # 7. Processes with the optimized plan
 ```
 
-The Smart Ingestion system ensures every document is processed optimally, regardless of its type or structure. It's the foundation of Nexus's quality-first approach!
+The Smart Ingestion system ensures every document is processed optimally, regardless of its type or structure. It's the foundation of llmfy's quality-first approach!
 

--- a/codex_report.md
+++ b/codex_report.md
@@ -6,7 +6,7 @@
 - Fixed truncated lines in `README.md` and added an AI generated content disclaimer.
 - Cleaned `requirements.txt` and restored final dependency line.
 - Updated `KnowledgeQualityAnalyzer` to use a portable default data path.
-- Replaced several lingering `Nexus` references with `llmfy`.
+- Replaced several lingering references with `llmfy`.
 - Installed optional dependency `chromadb` so tests collect properly.
 
 ## Testing

--- a/config/llmfy_config.yaml
+++ b/config/llmfy_config.yaml
@@ -1,4 +1,4 @@
-# Nexus AI Library Configuration
+# llmfy AI Library Configuration
 # Quality-First Knowledge Management System
 
 # Environment: development, test, production
@@ -68,7 +68,7 @@ storage:
       path: ./data/chromadb_prod
     cloud:
       type: pinecone
-      index: nexus-knowledge
+      index: llmfy-knowledge
       dimension: 1536
     routing:
       # Store in cloud if quality > 9.7
@@ -190,7 +190,7 @@ logging:
   
   # Log file settings
   file:
-    path: ./logs/nexus.log
+    path: ./logs/llmfy.log
     max_size_mb: 100
     backup_count: 5
   

--- a/llmfy.py
+++ b/llmfy.py
@@ -105,11 +105,11 @@ Examples:
     
     elif args.command == 'status':
         print_banner()
-        nexus_root = Path(__file__).parent
+        llmfy_root = Path(__file__).parent
         
         # Count documents
-        inbox_count = len(list((nexus_root / "data/inbox").glob("*.md")))
-        processed_count = len(list((nexus_root / "data/processed").glob("*.json")))
+        inbox_count = len(list((llmfy_root / "data/inbox").glob("*.md")))
+        processed_count = len(list((llmfy_root / "data/processed").glob("*.json")))
         
         console.print("\n[bold]System Status:[/bold]")
         console.print(f"  📥 Inbox: {inbox_count} documents")

--- a/llmfy_cache.py
+++ b/llmfy_cache.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-🧠 Nexus Cache Management Tool
+🧠 llmfy Cache Management Tool
 
-Manage the processing cache for the Nexus AI Library.
+Manage the processing cache for the llmfy AI Library.
 """
 
 import sys
@@ -93,7 +93,7 @@ def remove_from_cache(file_pattern: str):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Nexus Cache Management Tool"
+        description="llmfy Cache Management Tool"
     )
     
     subparsers = parser.add_subparsers(dest='command', help='Commands')

--- a/llmfy_ingest.py
+++ b/llmfy_ingest.py
@@ -89,7 +89,7 @@ def ingest_document(source_path: str, move: bool = True, smart: bool = True, aut
     else:
         # Simple ingestion without analysis
         console.print(Panel.fit(
-            f"[bold cyan]📥 Nexus Document Ingestion[/bold cyan]\n\n"
+            f"[bold cyan]📥 llmfy Document Ingestion[/bold cyan]\n\n"
             f"Source: {source.name}\n"
             f"Size: {source.stat().st_size:,} bytes\n"
             f"Destination: {dest.name}",
@@ -124,16 +124,16 @@ def main():
         epilog="""
 Examples:
   # Smart ingestion with analysis (recommended)
-  nexus_ingest document.md
+  llmfy_ingest document.md
   
   # Smart ingestion with auto-processing
-  nexus_ingest document.md --process
+  llmfy_ingest document.md --process
   
   # Simple ingestion without analysis
-  nexus_ingest document.md --no-smart
+  llmfy_ingest document.md --no-smart
   
   # Copy file instead of moving
-  nexus_ingest document.md --copy
+  llmfy_ingest document.md --copy
 """
     )
     parser.add_argument(

--- a/llmfy_quickstart.py
+++ b/llmfy_quickstart.py
@@ -19,8 +19,8 @@ console = Console()
 
 class llmfyQuickStart:
     def __init__(self):
-        self.nexus_root = Path(__file__).parent
-        self.venv_path = self.nexus_root / "venv"
+        self.llmfy_root = Path(__file__).parent
+        self.venv_path = self.llmfy_root / "venv"
         self.requirements = [
             "langchain>=0.0.300",
             "chromadb>=0.4.0",
@@ -195,11 +195,11 @@ enhancements:
 """
         
         # Create config directory
-        config_dir = self.nexus_root / "config"
+        config_dir = self.llmfy_root / "config"
         config_dir.mkdir(exist_ok=True)
         
         # Write configs
-        (config_dir / "nexus_config.yaml").write_text(main_config)
+        (config_dir / "llmfy_config.yaml").write_text(main_config)
         (config_dir / "quality_rules.yaml").write_text(quality_rules)
         
         console.print("[green]✅ Configuration files created[/green]")
@@ -214,10 +214,10 @@ OPENAI_API_KEY=your_api_key_here
 # Pinecone (for cloud storage)
 PINECONE_API_KEY=your_api_key_here
 PINECONE_ENV=us-east-1-aws
-PINECONE_INDEX_NAME=nexus-knowledge
+PINECONE_INDEX_NAME=llmfy-knowledge
 
 # Environment
-NEXUS_ENV=development
+LLMFY_ENV=development
 
 # Quality Settings
 QUALITY_THRESHOLD=9.5
@@ -229,7 +229,7 @@ CACHE_EMBEDDINGS=true
 MAX_MONTHLY_COST=100
 """
         
-        env_path = self.nexus_root / ".env"
+        env_path = self.llmfy_root / ".env"
         if not env_path.exists():
             env_path.write_text(env_template)
             console.print("[green]✅ .env template created[/green]")
@@ -269,7 +269,7 @@ except Exception as e:
 """
         
         # Write test script
-        test_path = self.nexus_root / "_test_install.py"
+        test_path = self.llmfy_root / "_test_install.py"
         test_path.write_text(test_script)
         
         # Run test
@@ -282,7 +282,7 @@ except Exception as e:
             [str(python_path), str(test_path)],
             capture_output=True,
             text=True,
-            cwd=str(self.nexus_root)
+            cwd=str(self.llmfy_root)
         )
         
         console.print(result.stdout)
@@ -305,9 +305,9 @@ except Exception as e:
             f"   [cyan]{self.venv_path}\\Scripts\\activate[/cyan] (Windows)\n\n"
             "2. Add your API keys to .env (for production)\n\n"
             "3. Process your first document:\n"
-            "   [cyan]python -m src.core.nexus_pipeline --input data/inbox/test.md[/cyan]\n\n"
+            "   [cyan]python -m src.core.llmfy_pipeline --input data/inbox/test.md[/cyan]\n\n"
             "4. Check quality scores:\n"
-            "   [cyan]python nexus_validator.py data/processed/[/cyan]\n\n"
+            "   [cyan]python llmfy_validator.py data/processed/[/cyan]\n\n"
             "[dim]Remember: Quality first. Every chunk must be 9.5/10 or higher.[/dim]",
             border_style="green"
         ))

--- a/llmfy_validator.py
+++ b/llmfy_validator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-🧪 Nexus Validator - Quality validation tool for processed documents
+🧪 llmfy Validator - Quality validation tool for processed documents
 
 Validates that all chunks in the system meet the 9.5/10 quality standard.
 """
@@ -25,9 +25,9 @@ from src.quality.quality_scorer import QualityAnalyzer
 
 console = Console()
 
-class NexusValidator:
+class LlmfyValidator:
     """
-    Validates document quality in the Nexus system.
+    Validates document quality in the llmfy system.
     
     Features:
     - Scan processed documents for quality scores
@@ -44,7 +44,7 @@ class NexusValidator:
     def validate_directory(self, directory: Path) -> Dict[str, Any]:
         """Validate all documents in a directory"""
         console.print(Panel.fit(
-            f"[bold cyan]🧪 Nexus Quality Validator[/bold cyan]\n"
+            f"[bold cyan]🧪 llmfy Quality Validator[/bold cyan]\n"
             f"Validating: {directory}\n"
             f"Quality Threshold: {self.quality_threshold}/10",
             border_style="cyan"
@@ -291,7 +291,7 @@ class NexusValidator:
 def main():
     """Command-line interface"""
     parser = argparse.ArgumentParser(
-        description="Nexus Quality Validator - Validate chunk quality"
+        description="llmfy Quality Validator - Validate chunk quality"
     )
     parser.add_argument(
         'path',
@@ -313,7 +313,7 @@ def main():
     args = parser.parse_args()
     
     # Initialize validator
-    validator = NexusValidator(quality_threshold=args.threshold)
+    validator = LlmfyValidator(quality_threshold=args.threshold)
     
     # Validate path
     path = Path(args.path)

--- a/process_ui_guide.py
+++ b/process_ui_guide.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Process the UI/UX Architecture Guide through Nexus
+Process the UI/UX Architecture Guide through llmfy
 """
 
 import sys
@@ -61,7 +61,7 @@ print("\n📦 Document would be processed into multiple chunks")
 print(f"Estimated chunks: ~{len(content) // 1500} chunks")
 
 print("\n🚀 To process the full document, run:")
-print("python -m src.core.nexus_pipeline --input data/inbox/architects_guide_ui_ux.md")
+print("python -m src.core.llmfy_pipeline --input data/inbox/architects_guide_ui_ux.md")
 print("\nThis will:")
 print("1. Split into optimal chunks")
 print("2. Assess quality of each chunk")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Nexus AI Library Requirements
+# llmfy AI Library Requirements
 
 # Core dependencies
 langchain>=0.0.300

--- a/src/core/llmfy_pipeline.py
+++ b/src/core/llmfy_pipeline.py
@@ -41,7 +41,7 @@ class LlmfyPipeline(KnowledgeBasePipeline):
     """
     
     def __init__(self, storage_mode: Optional[str] = None, quality_threshold: float = 7.0):
-        """Initialize Nexus Pipeline with quality features"""
+        """Initialize llmfy Pipeline with quality features"""
         super().__init__(storage_mode)
         
         # Use improved text processor
@@ -118,7 +118,7 @@ class LlmfyPipeline(KnowledgeBasePipeline):
                     'initial_quality_score': initial_score,
                     'quality_dimensions': quality_result['dimension_scores'],
                     'quality_assessed_at': datetime.now(timezone.utc).isoformat(),
-                    'nexus_version': '1.0'
+                    'llmfy_version': '1.0'
                 }
                 
                 # Check if enhancement needed
@@ -350,7 +350,7 @@ class LlmfyPipeline(KnowledgeBasePipeline):
 
 
 def main():
-    """Command-line interface for Nexus Pipeline"""
+    """Command-line interface for llmfy Pipeline"""
     import argparse
     
     parser = argparse.ArgumentParser(

--- a/src/core/smart_ingestion.py
+++ b/src/core/smart_ingestion.py
@@ -384,7 +384,7 @@ class SmartIngestionPlanner:
                 enhancement_strategies.append('expand_content')
         
         # Estimate costs
-        if os.getenv('NEXUS_ENV', 'development') == 'development':
+        if os.getenv('LLMFY_ENV', 'development') == 'development':
             estimated_cost = 0  # Free local embeddings
         else:
             # ~$0.0001 per 1K tokens, ~250 tokens per chunk

--- a/src/embeddings/hybrid_embedder.py
+++ b/src/embeddings/hybrid_embedder.py
@@ -33,7 +33,7 @@ class HybridEmbedder:
     
     def __init__(self, environment: str = None):
         """Initialize hybrid embedder"""
-        self.environment = environment or os.getenv('NEXUS_ENV', 'development')
+        self.environment = environment or os.getenv('LLMFY_ENV', 'development')
         
         # Initialize base embedder (has OpenAI)
         self.cloud_embedder = EmbeddingGenerator()

--- a/src/embeddings/hybrid_embedder_old.py
+++ b/src/embeddings/hybrid_embedder_old.py
@@ -40,7 +40,7 @@ class HybridEmbedder:
     
     def __init__(self, environment: str = None):
         """Initialize hybrid embedder"""
-        self.environment = environment or os.getenv('NEXUS_ENV', 'development')
+        self.environment = environment or os.getenv('LLMFY_ENV', 'development')
         
         # Initialize base embedder (has OpenAI)
         self.cloud_embedder = EmbeddingGenerator()

--- a/test_setup.py
+++ b/test_setup.py
@@ -33,7 +33,7 @@ key_files = [
     'src/quality/quality_scorer.py',
     'src/quality/quality_enhancer.py',
     'src/embeddings/hybrid_embedder.py',
-    'config/nexus_config.yaml',
+    'config/llmfy_config.yaml',
     '.env'
 ]
 


### PR DESCRIPTION
## Summary
- rename config file to `llmfy_config.yaml`
- rename `NexusValidator` class -> `LlmfyValidator`
- update environment variables and example commands
- scrub docs of remaining "Nexus" references

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_b_6881aa4f2cb48325a833b59adcf13bba